### PR TITLE
Address warnings about global parameters created in functions

### DIFF
--- a/autoload/tags/__from__
+++ b/autoload/tags/__from__
@@ -41,6 +41,8 @@ if [[ -z $from ]]; then
 fi
 
 : ${from:=$default}
+typeset -ga match
+typeset -gi mbegin mend
 if [[ ! $from =~ ^(${(j:|:)candidates[@]})$ ]]; then
     __zplug::io::print::f \
         --die \

--- a/base/core/arguments.zsh
+++ b/base/core/arguments.zsh
@@ -3,7 +3,7 @@ __zplug::core::arguments::exec()
     local arg="$1"
     shift
 
-    reply=()
+    typeset -ga reply=()
     __zplug::core::commands::user_defined
 
     # User-defined command

--- a/base/core/cache.zsh
+++ b/base/core/cache.zsh
@@ -32,7 +32,7 @@ __zplug::core::cache::commit()
     local -A  hook_load
     local -A  reply_hash
     local -A  load_commands
-    local -aU load_plugins load_fpaths lazy_plugins \
+    local -aU load_plugins load_fpaths lazy_plugins load_themes \
         defer_1_plugins \
         defer_2_plugins \
         defer_3_plugins

--- a/base/core/commands.zsh
+++ b/base/core/commands.zsh
@@ -10,7 +10,7 @@ __zplug::core::commands::user_defined()
     local -a user_cmds
 
     # reset
-    reply=()
+    typeset -ga reply=()
 
     user_cmds=( ${^path[@]}/zplug-*(N-.:t:gs:zplug-:) )
     if (( $#user_cmds > 0 )); then

--- a/base/core/core.zsh
+++ b/base/core/core.zsh
@@ -1,6 +1,6 @@
 __zplug::core::core::get_interfaces()
 {
-    local    arg name desc
+    local    arg name desc line
     local    target
     local -a targets
     local    interface
@@ -29,7 +29,7 @@ __zplug::core::core::get_interfaces()
     done
 
     # Initialize
-    reply=()
+    typeset -gA reply=()
 
     for target in "${targets[@]}"
     do
@@ -285,7 +285,7 @@ __zplug::core::core::variable()
 
     # zplug core variables
     {
-        typeset -gx -A -U \
+        typeset -gx -a -U \
             _zplug_options \
             _zplug_commands \
             _zplug_tags

--- a/base/core/options.zsh
+++ b/base/core/options.zsh
@@ -71,7 +71,7 @@ __zplug::core::options::long()
         esac
     done
 
-    opt="$opts[1]"
+    typeset -l opt="$opts[1]"
 
     if [[ -f $ZPLUG_ROOT/autoload/options/__${opt}__ ]]; then
         __zplug::core::core::run_interfaces \

--- a/base/core/tags.zsh
+++ b/base/core/tags.zsh
@@ -26,5 +26,5 @@ __zplug::core::tags::parse()
         pairs+=("$tag" "$val")
     done
 
-    reply=( "$pairs[@]" )
+    typeset -ga reply=( "$pairs[@]" )
 }

--- a/base/job/parallel.zsh
+++ b/base/job/parallel.zsh
@@ -129,6 +129,7 @@ __zplug::job::parallel::deinit()
             # Run rollback if hook-build failed
             __zplug::job::rollback::message
             # Cache clear automatically after running update command
+            typeset -l status_ok
             status_ok=( ${(@f)"$(cat "$_zplug_log[update]" 2>/dev/null \
                 | __zplug::utils::awk::ltsv 'key("status")==0')"} )
             if (( $#status_ok > 0 )); then


### PR DESCRIPTION
With zshopt WARNCREATEGLOBAL active, warnings such as the following are shown throughout use of zplug:

```
__zplug::core::core::get_interfaces:31: array parameter reply created globally in function __zplug::core::core::get_interfaces
__zplug::core::core::get_interfaces:45: scalar parameter line created globally in function __zplug::core::core::get_interfaces
__zplug::core::options::long:19: scalar parameter opt created globally in function __zplug::core::options::long
```

This patch addresses that by making sure that all those parameters are properly declared.

Signed-off-by: martin f. krafft <madduck@madduck.net>