### PR TITLE
Remove Perl dependency

### DIFF
--- a/base/utils/ansi.zsh
+++ b/base/utils/ansi.zsh
@@ -1,6 +1,6 @@
 __zplug::utils::ansi::remove()
 {
-    perl -pe 's/\e\[?.*?[\@-~]//g'
+    sed 's/\x1b\[[0-9;=?]*[a-zA-Z]/e/g'
 }
 
 __zplug::utils::ansi::erace_current_line()

--- a/base/utils/shell.zsh
+++ b/base/utils/shell.zsh
@@ -112,11 +112,6 @@ __zplug::utils::shell::sudo()
         | sudo -S -p '' "$argv[@]"
 }
 
-__zplug::utils::shell::unansi()
-{
-    perl -pe 's/\e\[?.*?[\@-~]//g'
-}
-
 __zplug::utils::shell::cd()
 {
     local    dir arg

--- a/bin/zplug-env
+++ b/bin/zplug-env
@@ -5,6 +5,4 @@
 # This is a sample zplug script
 # For more information, see man page of zplug(1)
 
-env \
-    | grep -E "^_?ZPLUG_" \
-    | perl -pe 's/^(\w+)(=)(.*)$/\033[32m$1\033[m $2 $3/'
+env | awk -v FS="=" '/^_?ZPLUG_/ {printf "\033[32m%s\033[m = %s\n", $1, $2}'

--- a/test/base/utils/shell.t
+++ b/test/base/utils/shell.t
@@ -10,9 +10,6 @@ T_SUB "__zplug::utils::shell::glob2regexp" ((
 T_SUB "__zplug::utils::shell::sudo" ((
   # skip
 ))
-T_SUB "__zplug::utils::shell::unansi" ((
-  # skip
-))
 T_SUB "__zplug::utils::shell::cd" ((
   # skip
 ))


### PR DESCRIPTION
Replaces every occurrence of Perl with equivalent awk or sed commands. Also removes unused __zplug::utils::shell::unansi function (which also used perl).